### PR TITLE
0.2.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-query/core",
-  "version": "0.1.0-dev.1",
+  "version": "0.2.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-query/core",
-  "version": "0.0.1",
+  "version": "0.1.0-dev.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -17,7 +17,7 @@ export class ContextQueryStore<TState extends TStateImpl> {
     return this.state[key];
   }
 
-  public updateState<TKey extends keyof TState>(state: TState): boolean {
+  public updateState<TKey extends keyof TState>(state: TState): void {
     const prevState = { ...this.state };
     this.state = { ...state };
     const keys = Object.keys(state) as TKey[];
@@ -27,23 +27,19 @@ export class ContextQueryStore<TState extends TStateImpl> {
         this.notifyListeners(key);
       }
     });
-
-    return true;
   }
 
   public setState<TKey extends keyof TState>(
     key: TKey,
     value: TState[TKey]
-  ): boolean {
+  ): void {
     if (Object.is(this.state[key], value)) {
-      return false;
+      return;
     }
 
     this.state = { ...this.state, [key]: value };
 
     this.notifyListeners(key);
-
-    return true;
   }
 
   private notifyListeners<TKey extends keyof TState>(key: TKey) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,4 +4,4 @@ export type Subscription = {
 
 export type Listener<T> = (value: T) => void;
 export type Updater<TState> = (state: TState) => Partial<TState>;
-export type TStateImpl = Record<string, unknown>;
+export type TStateImpl = Record<string, any>;

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@context-query/react": "latest",
+    "@context-query/react": "0.1.0-dev.1",
     "@radix-ui/react-slot": "^1.1.2",
     "@tailwindcss/vite": "^4.0.13",
     "class-variance-authority": "^0.7.1",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@context-query/react": "workspace:*",
+    "@context-query/react": "0.2.0",
     "@radix-ui/react-slot": "^1.1.2",
     "@tailwindcss/vite": "^4.0.13",
     "class-variance-authority": "^0.7.1",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@context-query/react": "0.1.0-dev.1",
+    "@context-query/react": "workspace:*",
     "@radix-ui/react-slot": "^1.1.2",
     "@tailwindcss/vite": "^4.0.13",
     "class-variance-authority": "^0.7.1",

--- a/packages/playground/src/ContextQueryImplementation.tsx
+++ b/packages/playground/src/ContextQueryImplementation.tsx
@@ -1,29 +1,30 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect } from "react";
 import { Button } from "./components/ui/button";
 import {
   CounterQueryProvider,
-  useCounterBatchQuery,
+  setCounterState,
+  updateCounterState,
   useCounterQuery,
 } from "./CounterContextQueryProvider";
 import { cqLogger } from "./LoggerInstance";
 
 function CQCounter3() {
-  const [state, setState] = useCounterQuery("count3");
+  const [{ count3 }, setState] = useCounterQuery(["count3"]);
 
   useEffect(() => {
-    cqLogger.log(`Counter3 컴포넌트 렌더링 - ${state}`);
+    cqLogger.log(`Counter3 컴포넌트 렌더링 - ${count3}`);
   });
 
   const increment = () => {
-    setState((prev) => prev + 1);
+    setState((prev) => ({ ...prev, count3: prev.count3 + 1 }));
   };
 
   const decrement = () => {
-    setState((prev) => prev - 1);
+    setState((prev) => ({ ...prev, count3: prev.count3 - 1 }));
   };
 
   const reset = () => {
-    setState(0);
+    setState({ count3: 0 });
   };
 
   return (
@@ -31,7 +32,7 @@ function CQCounter3() {
       <div className="p-6 space-y-4">
         <h2 className="text-lg font-semibold">카운터 3</h2>
         <div className="flex items-center justify-between gap-4">
-          <span className="text-2xl font-bold text-purple-600">{state}</span>
+          <span className="text-2xl font-bold text-purple-600">{count3}</span>
           <div className="flex gap-2">
             <Button size="sm" variant="outline" onClick={decrement}>
               감소
@@ -50,22 +51,22 @@ function CQCounter3() {
 }
 
 function CQCounter2() {
-  const [state, setState] = useCounterQuery("count2");
+  const [{ count2 }, setState] = useCounterQuery(["count2"]);
 
   useEffect(() => {
-    cqLogger.log(`Counter2 컴포넌트 렌더링 - ${state}`);
+    cqLogger.log(`Counter2 컴포넌트 렌더링 - ${count2}`);
   });
 
   const increment = () => {
-    setState((prev) => prev + 1);
+    setState((prev) => ({ ...prev, count2: prev.count2 + 1 }));
   };
 
   const decrement = () => {
-    setState((prev) => prev - 1);
+    setState((prev) => ({ ...prev, count2: prev.count2 - 1 }));
   };
 
   const reset = () => {
-    setState(0);
+    setState({ count2: 0 });
   };
 
   return (
@@ -74,7 +75,7 @@ function CQCounter2() {
         <div className="p-6 space-y-4">
           <h2 className="text-lg font-semibold">카운터 2</h2>
           <div className="flex items-center justify-between gap-4">
-            <span className="text-2xl font-bold text-green-600">{state}</span>
+            <span className="text-2xl font-bold text-green-600">{count2}</span>
             <div className="flex gap-2">
               <Button size="sm" variant="outline" onClick={decrement}>
                 감소
@@ -94,22 +95,22 @@ function CQCounter2() {
 }
 
 const CQCounter1 = () => {
-  const [state, setState] = useCounterQuery("count1");
+  const [state, setState] = useCounterQuery(["count1", "count2"]);
 
   useEffect(() => {
-    cqLogger.log(`Counter1 컴포넌트 렌더링 - ${state}`);
+    cqLogger.log(`Counter1 컴포넌트 렌더링 - ${state.count1} ${state.count2}`);
   });
 
   const increment = () => {
-    setState((prev) => prev + 1);
+    setState((prev) => ({ count1: prev.count1 + 1, count2: prev.count2 + 1 }));
   };
 
   const decrement = () => {
-    setState(state - 1);
+    setState((prev) => ({ count1: prev.count1 - 1, count2: prev.count2 - 1 }));
   };
 
   const reset = () => {
-    setState(0);
+    setState({ count1: 0, count2: 0 });
   };
 
   return (
@@ -118,7 +119,9 @@ const CQCounter1 = () => {
         <div className="p-6 space-y-4">
           <h2 className="text-lg font-semibold">카운터 1</h2>
           <div className="flex items-center justify-between gap-4">
-            <span className="text-2xl font-bold text-blue-600">{state}</span>
+            <span className="text-2xl font-bold text-blue-600">
+              {state.count1},{state.count2}
+            </span>
             <div className="flex gap-2">
               <Button size="sm" variant="outline" onClick={decrement}>
                 감소
@@ -138,28 +141,23 @@ const CQCounter1 = () => {
 };
 
 export function ContextQueryImplementation() {
-  const [counts, setCounts] = useState({ count1: 0, count2: 0, count3: 0 });
-
-  const initialState = useMemo(() => counts, [counts]);
-
   const incrementCount1 = () => {
-    setCounts((prevCounts) => ({
-      ...prevCounts,
-      count1: prevCounts.count1 + 1,
-    }));
+    setCounterState("count1", (prev) => prev + 1);
   };
 
   const incrementCount2 = () => {
-    setCounts((prevCounts) => ({
-      ...prevCounts,
-      count2: prevCounts.count2 + 1,
-    }));
+    setCounterState("count2", (prev) => prev + 1);
   };
 
   const incrementCount3 = () => {
-    setCounts((prevCounts) => ({
-      ...prevCounts,
-      count3: prevCounts.count3 + 1,
+    setCounterState("count3", (prev) => prev + 1);
+  };
+
+  const incrementAllCounts = () => {
+    updateCounterState((state) => ({
+      count1: state.count1 + 1,
+      count2: state.count2 + 1,
+      count3: state.count3 + 1,
     }));
   };
 
@@ -169,9 +167,9 @@ export function ContextQueryImplementation() {
         <Button onClick={incrementCount1}>count1 증가</Button>
         <Button onClick={incrementCount2}>count2 증가</Button>
         <Button onClick={incrementCount3}>count3 증가</Button>
+        <Button onClick={incrementAllCounts}>전체 증가</Button>
       </div>
-
-      <CounterQueryProvider initialState={initialState}>
+      <CounterQueryProvider>
         <div className="rounded-lg bg-card text-card-foreground shadow-sm p-4">
           <h2 className="text-xl font-bold mb-2">Context Query 버전</h2>
           <p className="text-muted-foreground mb-4">
@@ -182,6 +180,7 @@ export function ContextQueryImplementation() {
             <CQCounter1 />
             <CQCounter2 />
             <CQCounter3 />
+            <AllStateSub />
           </div>
 
           <BatchCounterControls />
@@ -193,14 +192,12 @@ export function ContextQueryImplementation() {
 
 // 새로운 컴포넌트 추가: 일괄 처리 컨트롤
 function BatchCounterControls() {
-  const batchUpdate = useCounterBatchQuery();
-
   useEffect(() => {
     cqLogger.log("BatchCounterControls 컴포넌트 렌더링");
   });
 
   const incrementAll = () => {
-    batchUpdate((state) => ({
+    updateCounterState((state) => ({
       count1: state.count1 + 1,
       count2: state.count2 + 1,
       count3: state.count3 + 1,
@@ -208,7 +205,7 @@ function BatchCounterControls() {
   };
 
   const decrementAll = () => {
-    batchUpdate((state) => ({
+    updateCounterState((state) => ({
       count1: state.count1 - 1,
       count2: state.count2 - 1,
       count3: state.count3 - 1,
@@ -216,7 +213,7 @@ function BatchCounterControls() {
   };
 
   const resetAll = () => {
-    batchUpdate(() => ({
+    updateCounterState(() => ({
       count1: 0,
       count2: 0,
       count3: 0,
@@ -224,7 +221,7 @@ function BatchCounterControls() {
   };
 
   const multiplyAll = () => {
-    batchUpdate((state) => ({
+    updateCounterState((state) => ({
       count1: state.count1 * 2,
       count2: state.count2 * 2,
       count3: state.count3 * 2,
@@ -251,6 +248,23 @@ function BatchCounterControls() {
           모두 2배
         </Button>
       </div>
+    </div>
+  );
+}
+
+function AllStateSub() {
+  const [state] = useCounterQuery();
+
+  useEffect(() => {
+    cqLogger.log("AllStateSub 컴포넌트 렌더링");
+  });
+
+  return (
+    <div>
+      <h2>AllStateSub</h2>
+      <p>{state.count1}</p>
+      <p>{state.count2}</p>
+      <p>{state.count3}</p>
     </div>
   );
 }

--- a/packages/playground/src/ContextQueryImplementation.tsx
+++ b/packages/playground/src/ContextQueryImplementation.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Button } from "./components/ui/button";
 import {
   CounterQueryProvider,
+  useCounterBatchQuery,
   useCounterQuery,
 } from "./CounterContextQueryProvider";
 import { cqLogger } from "./LoggerInstance";
@@ -182,8 +183,74 @@ export function ContextQueryImplementation() {
             <CQCounter2 />
             <CQCounter3 />
           </div>
+
+          <BatchCounterControls />
         </div>
       </CounterQueryProvider>
+    </div>
+  );
+}
+
+// 새로운 컴포넌트 추가: 일괄 처리 컨트롤
+function BatchCounterControls() {
+  const batchUpdate = useCounterBatchQuery();
+
+  useEffect(() => {
+    cqLogger.log("BatchCounterControls 컴포넌트 렌더링");
+  });
+
+  const incrementAll = () => {
+    batchUpdate((state) => ({
+      count1: state.count1 + 1,
+      count2: state.count2 + 1,
+      count3: state.count3 + 1,
+    }));
+  };
+
+  const decrementAll = () => {
+    batchUpdate((state) => ({
+      count1: state.count1 - 1,
+      count2: state.count2 - 1,
+      count3: state.count3 - 1,
+    }));
+  };
+
+  const resetAll = () => {
+    batchUpdate(() => ({
+      count1: 0,
+      count2: 0,
+      count3: 0,
+    }));
+  };
+
+  const multiplyAll = () => {
+    batchUpdate((state) => ({
+      count1: state.count1 * 2,
+      count2: state.count2 * 2,
+      count3: state.count3 * 2,
+    }));
+  };
+
+  return (
+    <div className="rounded-lg bg-card text-card-foreground shadow-sm mt-6 p-4 border-2 border-dashed border-purple-300">
+      <h2 className="text-lg font-semibold mb-3">일괄 처리 컨트롤</h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        모든 카운터를 한 번에 업데이트합니다
+      </p>
+      <div className="flex gap-2 flex-wrap">
+        <Button onClick={incrementAll} variant="default">
+          모두 증가
+        </Button>
+        <Button onClick={decrementAll} variant="outline">
+          모두 감소
+        </Button>
+        <Button onClick={resetAll} variant="secondary">
+          모두 초기화
+        </Button>
+        <Button onClick={multiplyAll} variant="destructive">
+          모두 2배
+        </Button>
+      </div>
     </div>
   );
 }

--- a/packages/playground/src/CounterContextQueryProvider.tsx
+++ b/packages/playground/src/CounterContextQueryProvider.tsx
@@ -3,6 +3,7 @@ import { createContextQuery } from "@context-query/react";
 export const {
   Provider: CounterQueryProvider,
   useContextQuery: useCounterQuery,
+  useContextBatchQuery: useCounterBatchQuery,
 } = createContextQuery<{
   count1: number;
   count2: number;

--- a/packages/playground/src/CounterContextQueryProvider.tsx
+++ b/packages/playground/src/CounterContextQueryProvider.tsx
@@ -3,9 +3,6 @@ import { createContextQuery } from "@context-query/react";
 export const {
   Provider: CounterQueryProvider,
   useContextQuery: useCounterQuery,
-  useContextBatchQuery: useCounterBatchQuery,
-} = createContextQuery<{
-  count1: number;
-  count2: number;
-  count3: number;
-}>();
+  updateState: updateCounterState,
+  setState: setCounterState,
+} = createContextQuery({ count1: 0, count2: 0, count3: 0 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@context-query/core": "workspace:*",
+    "@context-query/core": "0.2.0",
     "react": "^18.3.1"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-query/react",
-  "version": "0.0.1",
+  "version": "0.1.0-dev.1",
   "license": "MIT",
   "description": "React bindings for ContextQuery",
   "author": "Minyeoung Seo <tjalsdud89@naver.com>",
@@ -30,7 +30,7 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@context-query/core": "latest",
+    "@context-query/core": "0.1.0-dev.1",
     "react": "^18.3.1"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-query/react",
-  "version": "0.1.0-dev.1",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "React bindings for ContextQuery",
   "author": "Minyeoung Seo <tjalsdud89@naver.com>",
@@ -30,7 +30,7 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@context-query/core": "0.1.0-dev.1",
+    "@context-query/core": "workspace:*",
     "react": "^18.3.1"
   },
   "devDependencies": {

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -3,12 +3,7 @@ import { createContext } from "react";
 
 export const createContextQuery = <TState extends TStateImpl>() => {
   const StoreContext = createContext<ContextQueryStore<TState> | null>(null);
-  const ContextQuerySubscriptionContext = createContext<{
-    subscribe: ContextQueryStore<TState>["subscribe"] | null;
-  } | null>(null);
-
   return {
     StoreContext,
-    ContextQuerySubscriptionContext,
   };
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,16 +1,42 @@
-import { TStateImpl } from "@context-query/core";
+import { ContextQueryStore, TStateImpl } from "@context-query/core";
 import { createUseContextQuery } from "./hooks";
 import { createReactContextQuery } from "./provider";
 
-export function createContextQuery<TState extends TStateImpl>() {
-  const { Provider, contexts } = createReactContextQuery<TState>();
+export function createContextQuery<TState extends TStateImpl>(
+  initialState: TState
+) {
+  const store = new ContextQueryStore<TState>(initialState);
 
-  const { useContextQuery, useContextBatchQuery } =
-    createUseContextQuery<TState>(contexts);
+  const { Provider, contexts } = createReactContextQuery<TState>(store);
+  const useContextQuery = createUseContextQuery<TState>(contexts);
+
+  const updateState = (state: TState | ((prev: TState) => TState)) => {
+    if (typeof state === "function") {
+      const updateFn = state as (prev: TState) => TState;
+      const currentValue = store.getState();
+      store.updateState(updateFn(currentValue));
+    } else {
+      store.updateState(state);
+    }
+  };
+
+  const setState = <TKey extends keyof TState>(
+    key: TKey,
+    value: TState[TKey] | ((prev: TState[TKey]) => TState[TKey])
+  ) => {
+    if (typeof value === "function") {
+      const updateFn = value as (prev: TState[TKey]) => TState[TKey];
+      const currentValue = store.getStateByKey(key);
+      store.setState(key, updateFn(currentValue));
+    } else {
+      store.setState(key, value);
+    }
+  };
 
   return {
     Provider,
     useContextQuery,
-    useContextBatchQuery,
+    updateState,
+    setState,
   };
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,10 +5,12 @@ import { createReactContextQuery } from "./provider";
 export function createContextQuery<TState extends TStateImpl>() {
   const { Provider, contexts } = createReactContextQuery<TState>();
 
-  const useContextQuery = createUseContextQuery<TState>(contexts);
+  const { useContextQuery, useContextBatchQuery } =
+    createUseContextQuery<TState>(contexts);
 
   return {
     Provider,
     useContextQuery,
+    useContextBatchQuery,
   };
 }

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,50 +1,30 @@
 import { ContextQueryStore, TStateImpl } from "@context-query/core";
-import { FC, PropsWithChildren, useEffect, useRef } from "react";
+import { FC, PropsWithChildren } from "react";
 import { createContextQuery } from "./context";
 
-export interface ProviderProps<TState extends TStateImpl>
-  extends PropsWithChildren {
-  initialState: TState;
-}
+export type ProviderProps<TState extends TStateImpl> = PropsWithChildren;
 
 export const createContextQueryProvider = <TState extends TStateImpl>(
-  contexts: ReturnType<typeof createContextQuery<TState>>
+  contexts: ReturnType<typeof createContextQuery<TState>>,
+  store: ContextQueryStore<TState>
 ): FC<ProviderProps<TState>> => {
   const { StoreContext } = contexts;
 
-  return function ContextQueryProvider({
-    children,
-    initialState,
-  }: ProviderProps<TState>) {
-    const storeRef = useRef<ContextQueryStore<TState> | null>(null);
-    const previousStateRef = useRef<TState | null>(null);
-
-    if (!storeRef.current) {
-      storeRef.current = new ContextQueryStore<TState>(initialState);
-      previousStateRef.current = initialState;
-    }
-
-    useEffect(() => {
-      if (
-        storeRef.current &&
-        !Object.is(previousStateRef.current, initialState)
-      ) {
-        storeRef.current.updateState(initialState);
-        previousStateRef.current = initialState;
-      }
-    }, [initialState]);
-
+  return function ContextQueryProvider({ children }: ProviderProps<TState>) {
     return (
-      <StoreContext.Provider value={storeRef.current}>
-        {children}
-      </StoreContext.Provider>
+      <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
     );
   };
 };
 
-export function createReactContextQuery<TState extends TStateImpl>() {
+export function createReactContextQuery<TState extends TStateImpl>(
+  store: ContextQueryStore<TState>
+) {
   const contexts = createContextQuery<TState>();
-  const ContextQueryProvider = createContextQueryProvider<TState>(contexts);
+  const ContextQueryProvider = createContextQueryProvider<TState>(
+    contexts,
+    store
+  );
 
   return {
     Provider: ContextQueryProvider,

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,5 +1,5 @@
 import { ContextQueryStore, TStateImpl } from "@context-query/core";
-import { FC, PropsWithChildren, useEffect, useMemo, useRef } from "react";
+import { FC, PropsWithChildren, useEffect, useRef } from "react";
 import { createContextQuery } from "./context";
 
 export interface ProviderProps<TState extends TStateImpl>
@@ -10,7 +10,7 @@ export interface ProviderProps<TState extends TStateImpl>
 export const createContextQueryProvider = <TState extends TStateImpl>(
   contexts: ReturnType<typeof createContextQuery<TState>>
 ): FC<ProviderProps<TState>> => {
-  const { StoreContext, ContextQuerySubscriptionContext } = contexts;
+  const { StoreContext } = contexts;
 
   return function ContextQueryProvider({
     children,
@@ -34,22 +34,9 @@ export const createContextQueryProvider = <TState extends TStateImpl>(
       }
     }, [initialState]);
 
-    const contextQuerySubscriptionContextValue = useMemo(
-      () => ({
-        subscribe: storeRef.current
-          ? storeRef.current.subscribe.bind(storeRef.current)
-          : null,
-      }),
-      [storeRef.current]
-    );
-
     return (
       <StoreContext.Provider value={storeRef.current}>
-        <ContextQuerySubscriptionContext.Provider
-          value={contextQuerySubscriptionContextValue}
-        >
-          {children}
-        </ContextQuerySubscriptionContext.Provider>
+        {children}
       </StoreContext.Provider>
     );
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
   packages/playground:
     dependencies:
       '@context-query/react':
-        specifier: workspace:*
-        version: link:../react
+        specifier: 0.1.0-dev.1
+        version: 0.1.0-dev.1(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@19.0.10)(react@19.0.0)
@@ -129,8 +129,8 @@ importers:
   packages/react:
     dependencies:
       '@context-query/core':
-        specifier: workspace:*
-        version: link:../core
+        specifier: 0.1.0-dev.1
+        version: 0.1.0-dev.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -227,6 +227,14 @@ packages:
   '@babel/types@7.26.10':
     resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
     engines: {node: '>=6.9.0'}
+
+  '@context-query/core@0.1.0-dev.1':
+    resolution: {integrity: sha512-BZR5vxtOz4zC27GXytmfsqrOLIFAeJWyDILaJ0HvlNXdKVp/ZOieuKF1N9YcsC1EMYuWeDfJMfV2w3F65DteGw==}
+
+  '@context-query/react@0.1.0-dev.1':
+    resolution: {integrity: sha512-bAS7G+JUms/xykvvx6UCbit2/09RntfTVVLEwLPKuTypW1qrUM1QSlA4RB/ZY970YA+l2zjYFLumfKwRLt98eA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   '@esbuild/aix-ppc64@0.25.1':
     resolution: {integrity: sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==}
@@ -1710,6 +1718,13 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@context-query/core@0.1.0-dev.1': {}
+
+  '@context-query/react@0.1.0-dev.1(react@19.0.0)':
+    dependencies:
+      '@context-query/core': 0.1.0-dev.1
+      react: 19.0.0
 
   '@esbuild/aix-ppc64@0.25.1':
     optional: true


### PR DESCRIPTION
### useContextQuery 훅 변경
- 배열로 여러개의 키를 이용해 상태를 구독 할 수 있게 변경
- 키값을 전달하지 않을때에는 모든 상태를 구독 하도록 추가

### ContextQueryProvider의 초기값 삭제
- ContextQueryProvider의 초기값 삭제
- 초기화는 createContextQuery 함수의 인자로 전달
- **이에 따라 ContextQueryProvider 외부에서 상태를 초기화 시키거나 변경 할때에는 스토어의 updateState, setState 사용 (Readme 파일의 예시 코드를 참조)**

### 렌더링 최적화
- ContextQueryProvider에 props로 값을 전달하지 않게 변경하므로 불필요한 리렌더링을 없애고 상태가 업데이트 된 시점에만 정확히 리렌더링을 할 수 있도록 개선

### 리팩토링
- 불필요한 SubscriptionProvider 삭제

### 버그
- Store의 상태 타입을 Record<string, unkown>에서 Record<string, any>로 변경